### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@6cee6086f1bf4467050e9a51e94bfb71b44cbc39 # v1.10.8
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
REF: [DX-516](https://linear.app/customerio/issue/DX-516/update-all-github-action-libraries-to-use-sha-instead-of-version) Pins GitHub Actions as part of DX-516.