### PR TITLE
DX-809 update to use preferred OIDC for npm publish in github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
       - run: npm run build
       - run: npm run test
       - run: npm version 0.0.0-test-oidc --no-git-tag-version
-      - run: npm publish --dry-run --access public
+      - run: npm publish --dry-run --tag test-oidc --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,6 @@ on:
     types:
       - published
 
-  pull_request:
-    types:
-      - opened
-      - synchronize
-
   workflow_dispatch:
 
 jobs:
@@ -29,5 +24,4 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
-      - run: npm version 0.0.0-test-oidc --no-git-tag-version
-      - run: npm publish --tag test-oidc --access public
+      - run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - name: Install npm 11.5.1+ for OIDC support
         run: npm install -g npm@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,5 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
-      - run: npm publish --dry-run --tag 0.0.0-test-oidc --access public
+      - run: npm version 0.0.0-test-oidc --no-git-tag-version
+      - run: npm publish --dry-run --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,15 +9,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
+      - name: Install npm 11.5.1+ for OIDC support
+        run: npm install -g npm@latest
       - run: npm install
       - run: npm run build
       - run: npm run test
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
     types:
       - published
 
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
   workflow_dispatch:
 
 jobs:
@@ -24,4 +29,4 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run test
-      - run: npm publish --access public
+      - run: npm publish --dry-run --tag 0.0.0-test-oidc --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,4 +30,4 @@ jobs:
       - run: npm run build
       - run: npm run test
       - run: npm version 0.0.0-test-oidc --no-git-tag-version
-      - run: npm publish --dry-run --tag test-oidc --access public
+      - run: npm publish --tag test-oidc --access public


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the publish workflow to use OIDC (with appropriate permissions), Node 20, and latest actions, removing the need for NPM token.
> 
> - **CI/CD (`.github/workflows/publish.yml`)**:
>   - **OIDC enablement**: Adds `environment: release` and `permissions` (`id-token: write`, `contents: read`); removes `NODE_AUTH_TOKEN` usage.
>   - **Runtime updates**: Upgrades to `actions/checkout@v4`, `actions/setup-node@v4`, and `node-version: 20`.
>   - **NPM**: Installs latest npm globally for OIDC support; continues publish with `npm publish --access public`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eda89c6ad3c7f69f986f1c090ee8d87de1a48984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->