### PR TITLE
fix(deps): resolve 3rd-party vulnerabilities (MBL-1693)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,15 @@
   "homepage": "https://github.com/customerio/devices#readme",
   "lint-staged": {
     "*.ts": "eslint --cache --fix"
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.3",
+    "semver": "7.5.2",
+    "yaml": "2.8.3",
+    "picomatch": "4.0.4",
+    "brace-expansion": "2.0.3",
+    "ws": "7.5.10",
+    "minimatch": "8.0.6",
+    "js-yaml": "4.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Addresses [MBL-1693](https://linear.app/customerio/issue/MBL-1693) — Fix 3rd-party vulnerabilities (Breaking) in `devices`.

Companion to PR #8 (MBL-1675, Non-Breaking) — that PR uses
`security/fix-3rd-party-vulnerabilities`, so this Breaking variant uses
`security/fix-3rd-party-vulnerabilities-breaking`.

### npm overrides

| Package | From | To | Advisory |
|---|---|---|---|
| serialize-javascript | 6.0.0 | **7.0.3** | GHSA-qj8w-gfj5-8c6v (RCE), CVE-2026-34043, CVE-2024-11831 |
| semver | 6.3.0 | **7.5.2** | CVE-2022-25883 |
| yaml | 2.1.1 | **2.8.3** | CVE-2023-2251, CVE-2026-33532 (Socket's `2 -> 1` downgrade is bogus; using 2.8.3 to match the pattern from PR #8) |
| picomatch | 2.3.1 | **4.0.4** | CVE-2026-33671, -33672 |
| brace-expansion | 1.1.11 | **2.0.3** | GHSA-v6h2-p8h4-qcjw |
| ws | 8.5.0 | **7.5.10** | CVE-2024-37890 |
| minimatch | 3.1.2 | **8.0.6** | CVE-2026-26996, -27904, -27903 |
| js-yaml | 3.14.1 | **4.1.1** | CVE-2025-64718 |

### Skipped

- **diff 4.0.2 -> 3.5.1**: Socket's downgrade heuristic; not following it. Will revisit
  if `npm audit` (in CI) still flags `diff` after the other overrides cascade.

### Notes

- Manifest-only change. `package-lock.json` will be regenerated by CI.
- Some overrides here may overlap with PR #8 once it merges (`ws`, `js-yaml`, `yaml`); rebase will combine cleanly.

## Test plan

- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only dependency pinning; low code risk, but may cause install/build incompatibilities if overridden transitive versions are not compatible with upstream packages.
> 
> **Overview**
> Adds an npm `overrides` block to `package.json` to force upgraded versions of several vulnerable transitive dependencies (e.g., `serialize-javascript`, `semver`, `yaml`, `ws`, `minimatch`, `js-yaml`).
> 
> This is a manifest-only change intended to remediate third‑party security advisories by pinning patched versions during install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b389292eff9d2ac928658ab0d9ef42e88e366a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->